### PR TITLE
Fix: Include audio track when downloading Nebula video

### DIFF
--- a/NebulaScript.js
+++ b/NebulaScript.js
@@ -810,6 +810,8 @@ function contentToPlatformVideoDetails(c, manifest_url) {
     const pv = contentToPlatformVideo(c)
     const pvd = new PlatformVideoDetails(pv)
     pvd.description = c.description === undefined ? c.class.description : c.description
+    // Nebula is English-only: no language metadata in the API, and HLS
+    // manifests contain a single audio track with no alternate languages.
     if (c.images === undefined) {
         pvd.video = new UnMuxVideoSourceDescriptor([], [new AudioUrlSource({
             name: "English",
@@ -821,9 +823,10 @@ function contentToPlatformVideoDetails(c, manifest_url) {
             language: "en"
         })])
     } else {
-        pvd.video = new VideoSourceDescriptor([
-            new HLSSource({ name: 'hls', duration: c.duration, url: manifest_url })
-        ])
+        pvd.video = new UnMuxVideoSourceDescriptor(
+            [new HLSSource({ name: 'hls', duration: c.duration, url: manifest_url })],
+            [new HLSSource({ name: 'hls', duration: c.duration, url: manifest_url, language: 'en' })]
+        )
         pvd.subtitles = [{
             name: "English",
             format: "text/vtt",


### PR DESCRIPTION
Switch video source descriptor from VideoSourceDescriptor (muxed) to UnMuxVideoSourceDescriptor (unmuxed) so Grayjay's download pipeline picks up the audio track from the HLS manifest.

This has been frustrating because I haven't been able to add nebula videos to my watch later as they would auto download then I can't watch them without deleting them because they were silent.


Disclosure: I used Claude Opus 4.5 to fix it. I tested it myself and it works without a hitch.